### PR TITLE
Adding setup script, hdf5-1.14.3, and updating CMakeLists.txt for installation on Stampede3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,9 @@ if ( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
 	else()
 	    set(OPTFLAG $ENV{ARCH_OPT_FLAG})
 	endif()
-        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O3 -traceback -mkl -heap-arrays 1024 -warn all ${OPTFLAG} -dynamic -qopt-report=2 -qopt-report-phase=vec -qopenmp")
+        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O3 -traceback -qmkl -heap-arrays 1024 -warn all ${OPTFLAG} -dynamic -qopt-report=2 -qopt-report-phase=vec -qopenmp")
     elseif ( CMAKE_BUILD_TYPE MATCHES "Debug" )
-        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -g -mkl -heap-arrays 1024 -check all -check noarg-temp-created -fpe0 -warn -traceback -debug extended -assume realloc_lhs -fstack-protector -assume protect_parens -implicitnone")
+        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -g -qmkl -heap-arrays 1024 -check all,nouninit -check noarg-temp-created -fpe0 -warn -traceback -debug extended -assume realloc_lhs -fstack-protector -assume protect_parens -implicitnone")
     endif()
 
 # GNU compiler on OSX

--- a/setup/SetupEnv_Stampede3.sh
+++ b/setup/SetupEnv_Stampede3.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+module load cmake
+module load intel impi
+
+CWD=`pwd`
+export COMPILER_ID=Intel
+export FC=mpiifort
+export CC=mpiicc
+export CXX=mpiicpc
+export FFTW_PATH=${CWD}/dependencies/fftw-3.3.10
+export DECOMP_PATH=${CWD}/dependencies/2decomp_fft
+export VTK_IO_PATH=${CWD}/dependencies/Lib_VTK_IO/build
+export HDF5_PATH=${CWD}/dependencies/hdf5-1.14.3/build
+export FFTPACK_PATH=${CWD}/dependencies/fftpack
+export ARCH_OPT_FLAG="-xCORE-AVX512"


### PR DESCRIPTION
Updating package versions for Stampede3:

fftw-3.3.5 --> fftw-3.3.10
hdf5-1.8.18 --> hdf5-1.14.3

Adding a setup script for compiling and updating the compiler flags in CMakeLists.txt for compatibility with the intel compiler on Stampede3.