### PR TITLE
Fix budget aliasing on edge fields

### DIFF
--- a/src/incompressible/budget_time_avg.F90
+++ b/src/incompressible/budget_time_avg.F90
@@ -235,6 +235,7 @@ module budgets_time_avg_mod
         procedure, private :: interp_Edge2Cell
         procedure, private :: interp_Cell2Edge
         procedure, private :: multiply_CellFieldsOnEdges
+        procedure, private :: multiply_Edges_interp_cell
     end type 
 
 
@@ -631,14 +632,10 @@ contains
         this%budget_0(:,:,:,4) = this%budget_0(:,:,:,4) + this%igrid_sim%u*this%igrid_sim%u
         this%budget_0(:,:,:,5) = this%budget_0(:,:,:,5) + this%igrid_sim%u*this%igrid_sim%v
         ! compute u'w' on edge cells for implicit dealiasing
-        this%igrid_sim%rbuffxE(:,:,:,1) = this%igrid_sim%uE * this%igrid_sim%w
-        call this%interp_Edge2Cell(this%igrid_sim%rbuffxE(:,:,:,1), this%igrid_sim%rbuffxC(:,:,:,1))
-        this%budget_0(:,:,:,6) = this%budget_0(:,:,:,6) + this%igrid_sim%rbuffxC(:,:,:,1)
+        this%budget_0(:,:,:,6) = this%budget_0(:,:,:,6) + this%multiply_Edges_interp_cell(this%igrid_sim%uE, this%igrid_sim%w)
         this%budget_0(:,:,:,7) = this%budget_0(:,:,:,7) + this%igrid_sim%v*this%igrid_sim%v
         ! compute v'w' on edge cells for implicit dealiasing
-        this%igrid_sim%rbuffxE(:,:,:,1) = this%igrid_sim%vE * this%igrid_sim%w
-        call this%interp_Edge2Cell(this%igrid_sim%rbuffxE(:,:,:,1), this%igrid_sim%rbuffxC(:,:,:,1))
-        this%budget_0(:,:,:,8) = this%budget_0(:,:,:,8) + this%igrid_sim%rbuffxC(:,:,:,1)
+        this%budget_0(:,:,:,8) = this%budget_0(:,:,:,8) + this%multiply_Edges_interp_cell(this%igrid_sim%vE, this%igrid_sim%w)
         this%budget_0(:,:,:,9) = this%budget_0(:,:,:,9) + this%igrid_sim%wC*this%igrid_sim%wC        
         ! STEP 3: Pressure
         this%budget_0(:,:,:,10) = this%budget_0(:,:,:,10) + this%igrid_sim%pressure
@@ -678,9 +675,7 @@ contains
             this%budget_0(:,:,:,27) = this%budget_0(:,:,:,27) + this%igrid_sim%u*this%igrid_sim%T
             this%budget_0(:,:,:,28) = this%budget_0(:,:,:,28) + this%igrid_sim%v*this%igrid_sim%T
             ! compute w'T' on edge cells for implicit dealiasing
-            this%igrid_sim%rbuffxE(:,:,:,1) = this%igrid_sim%TE * this%igrid_sim%w
-            call this%interp_Edge2Cell(this%igrid_sim%rbuffxE(:,:,:,1), this%igrid_sim%rbuffxC(:,:,:,1))
-            this%budget_0(:,:,:,29) = this%budget_0(:,:,:,29) + this%igrid_sim%rbuffxC(:,:,:,1)
+            this%budget_0(:,:,:,29) = this%budget_0(:,:,:,29) +  this%multiply_Edges_interp_cell(this%igrid_sim%TE, this%igrid_sim%w)
             this%budget_0(:,:,:,30) = this%budget_0(:,:,:,30) + this%igrid_sim%T*this%igrid_sim%T
         end if
 
@@ -2601,4 +2596,14 @@ subroutine DumpBudget4_23(this)
         call transpose_y_to_x(this%igrid_sim%rbuffyC(:,:,:,1),fmultC,this%igrid_sim%gpC)
 
     end subroutine 
+
+    ! multiply on edge cells and interpolate to cell centers to reduce aliasing issues
+    function multiply_Edges_interp_cell(this, f1E, f2E) result(fmultC)
+        class(budgets_time_avg), intent(inout) :: this
+        real(rkind), dimension(this%igrid_sim%gpE%xsz(1),this%igrid_sim%gpE%xsz(2),this%igrid_sim%gpE%xsz(3)), intent(in) :: f1E,f2E
+        real(rkind), dimension(this%igrid_sim%gpC%xsz(1),this%igrid_sim%gpC%xsz(2),this%igrid_sim%gpC%xsz(3)) :: fmultC
+
+        call this%interp_Edge2Cell(f1E * f2E, fmultC)
+    end function
+
 end module 

--- a/src/incompressible/budget_time_avg.F90
+++ b/src/incompressible/budget_time_avg.F90
@@ -630,11 +630,16 @@ contains
         ! STEP 2: Get Reynolds stresses (IMPORTANT: need to correct for fluctuation before dumping)
         this%budget_0(:,:,:,4) = this%budget_0(:,:,:,4) + this%igrid_sim%u*this%igrid_sim%u
         this%budget_0(:,:,:,5) = this%budget_0(:,:,:,5) + this%igrid_sim%u*this%igrid_sim%v
-        this%budget_0(:,:,:,6) = this%budget_0(:,:,:,6) + this%igrid_sim%u*this%igrid_sim%wC
+        ! compute u'w' on edge cells for implicit dealiasing
+        this%igrid_sim%rbuffxE(:,:,:,1) = this%igrid_sim%uE * this%igrid_sim%w
+        call this%interp_Edge2Cell(this%igrid_sim%rbuffxE(:,:,:,1), this%igrid_sim%rbuffxC(:,:,:,1))
+        this%budget_0(:,:,:,6) = this%budget_0(:,:,:,6) + this%igrid_sim%rbuffxC(:,:,:,1)
         this%budget_0(:,:,:,7) = this%budget_0(:,:,:,7) + this%igrid_sim%v*this%igrid_sim%v
-        this%budget_0(:,:,:,8) = this%budget_0(:,:,:,8) + this%igrid_sim%v*this%igrid_sim%wC
-        this%budget_0(:,:,:,9) = this%budget_0(:,:,:,9) + this%igrid_sim%wC*this%igrid_sim%wC
-
+        ! compute v'w' on edge cells for implicit dealiasing
+        this%igrid_sim%rbuffxE(:,:,:,1) = this%igrid_sim%vE * this%igrid_sim%w
+        call this%interp_Edge2Cell(this%igrid_sim%rbuffxE(:,:,:,1), this%igrid_sim%rbuffxC(:,:,:,1))
+        this%budget_0(:,:,:,8) = this%budget_0(:,:,:,8) + this%igrid_sim%rbuffxC(:,:,:,1)
+        this%budget_0(:,:,:,9) = this%budget_0(:,:,:,9) + this%igrid_sim%wC*this%igrid_sim%wC        
         ! STEP 3: Pressure
         this%budget_0(:,:,:,10) = this%budget_0(:,:,:,10) + this%igrid_sim%pressure
 
@@ -672,7 +677,10 @@ contains
         if (this%isStratified) then
             this%budget_0(:,:,:,27) = this%budget_0(:,:,:,27) + this%igrid_sim%u*this%igrid_sim%T
             this%budget_0(:,:,:,28) = this%budget_0(:,:,:,28) + this%igrid_sim%v*this%igrid_sim%T
-            this%budget_0(:,:,:,29) = this%budget_0(:,:,:,29) + this%igrid_sim%wC*this%igrid_sim%T
+            ! compute w'T' on edge cells for implicit dealiasing
+            this%igrid_sim%rbuffxE(:,:,:,1) = this%igrid_sim%TE * this%igrid_sim%w
+            call this%interp_Edge2Cell(this%igrid_sim%rbuffxE(:,:,:,1), this%igrid_sim%rbuffxC(:,:,:,1))
+            this%budget_0(:,:,:,29) = this%budget_0(:,:,:,29) + this%igrid_sim%rbuffxC(:,:,:,1)
             this%budget_0(:,:,:,30) = this%budget_0(:,:,:,30) + this%igrid_sim%T*this%igrid_sim%T
         end if
 

--- a/src/incompressible/budget_time_avg_deficit.F90
+++ b/src/incompressible/budget_time_avg_deficit.F90
@@ -251,6 +251,7 @@ module budgets_time_avg_deficit_mod
          procedure, private :: interp_Edge2Cell
          procedure, private :: interp_Cell2Edge
          procedure, private :: multiply_CellFieldsOnEdges
+         procedure, private :: multiply_edges_interp_cell
      end type 
  
  
@@ -555,20 +556,26 @@ module budgets_time_avg_deficit_mod
          ! STEP 3: Get Reynolds stresses (IMPORTANT: need to correct for fluctuation before dumping)
          this%budget_0(:,:,:,5) = this%budget_0(:,:,:,5) + (this%prim_budget%igrid_sim%u - this%pre_budget%igrid_sim%u) * (this%prim_budget%igrid_sim%u - this%pre_budget%igrid_sim%u)
          this%budget_0(:,:,:,6) = this%budget_0(:,:,:,6) + (this%prim_budget%igrid_sim%u - this%pre_budget%igrid_sim%u) * (this%prim_budget%igrid_sim%v - this%pre_budget%igrid_sim%v)
-         this%budget_0(:,:,:,7) = this%budget_0(:,:,:,7) + (this%prim_budget%igrid_sim%u - this%pre_budget%igrid_sim%u) * (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC)
+        !  this%budget_0(:,:,:,7) = this%budget_0(:,:,:,7) + (this%prim_budget%igrid_sim%u - this%pre_budget%igrid_sim%u) * (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC)
+         this%budget_0(:,:,:,7) = this%budget_0(:,:,:,7) + this%multiply_Edges_interp_cell(this%prim_budget%igrid_sim%uE - this%pre_budget%igrid_sim%uE, this%prim_budget%igrid_sim%w - this%pre_budget%igrid_sim%w)
          this%budget_0(:,:,:,8) = this%budget_0(:,:,:,8) + (this%prim_budget%igrid_sim%v - this%pre_budget%igrid_sim%v) * (this%prim_budget%igrid_sim%v - this%pre_budget%igrid_sim%v)
-         this%budget_0(:,:,:,9) = this%budget_0(:,:,:,9) + (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC) * (this%prim_budget%igrid_sim%v - this%pre_budget%igrid_sim%v)
+        !  this%budget_0(:,:,:,9) = this%budget_0(:,:,:,9) + (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC) * (this%prim_budget%igrid_sim%v - this%pre_budget%igrid_sim%v)
+         this%budget_0(:,:,:,9) = this%budget_0(:,:,:,9) + this%multiply_Edges_interp_cell(this%prim_budget%igrid_sim%vE - this%pre_budget%igrid_sim%vE, this%prim_budget%igrid_sim%w - this%pre_budget%igrid_sim%w)
          this%budget_0(:,:,:,10) = this%budget_0(:,:,:,10) + (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC) * (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC)
          
          ! STEP 4: Get mixed Reynolds stresses
          this%budget_0(:,:,:,11) = this%budget_0(:,:,:,11) + (this%prim_budget%igrid_sim%u - this%pre_budget%igrid_sim%u) * (this%pre_budget%igrid_sim%u) 
          this%budget_0(:,:,:,12) = this%budget_0(:,:,:,12) + (this%prim_budget%igrid_sim%u - this%pre_budget%igrid_sim%u) * (this%pre_budget%igrid_sim%v)
          this%budget_0(:,:,:,13) = this%budget_0(:,:,:,13) + (this%prim_budget%igrid_sim%v - this%pre_budget%igrid_sim%v) * (this%pre_budget%igrid_sim%u)
-         this%budget_0(:,:,:,14) = this%budget_0(:,:,:,14) + (this%prim_budget%igrid_sim%u - this%pre_budget%igrid_sim%u) * (this%pre_budget%igrid_sim%wC)
-         this%budget_0(:,:,:,15) = this%budget_0(:,:,:,15) + (this%pre_budget%igrid_sim%u) * (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC)
+        !  this%budget_0(:,:,:,14) = this%budget_0(:,:,:,14) + (this%prim_budget%igrid_sim%u - this%pre_budget%igrid_sim%u) * (this%pre_budget%igrid_sim%wC)
+         this%budget_0(:,:,:,14) = this%budget_0(:,:,:,14) + this%multiply_Edges_interp_cell(this%prim_budget%igrid_sim%uE - this%pre_budget%igrid_sim%uE, this%pre_budget%igrid_sim%w)
+        !  this%budget_0(:,:,:,15) = this%budget_0(:,:,:,15) + (this%pre_budget%igrid_sim%u) * (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC)
+         this%budget_0(:,:,:,15) = this%budget_0(:,:,:,15) + this%multiply_Edges_interp_cell(this%pre_budget%igrid_sim%uE, this%prim_budget%igrid_sim%w - this%pre_budget%igrid_sim%w)
          this%budget_0(:,:,:,16) = this%budget_0(:,:,:,16) + (this%prim_budget%igrid_sim%v - this%pre_budget%igrid_sim%v) * (this%pre_budget%igrid_sim%v)
-         this%budget_0(:,:,:,17) = this%budget_0(:,:,:,17) + (this%pre_budget%igrid_sim%wC) * (this%prim_budget%igrid_sim%v - this%pre_budget%igrid_sim%v)
-         this%budget_0(:,:,:,18) = this%budget_0(:,:,:,18) + (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC) * (this%pre_budget%igrid_sim%v)
+        !  this%budget_0(:,:,:,17) = this%budget_0(:,:,:,17) + (this%pre_budget%igrid_sim%wC) * (this%prim_budget%igrid_sim%v - this%pre_budget%igrid_sim%v)
+         this%budget_0(:,:,:,17) = this%budget_0(:,:,:,17) + this%multiply_Edges_interp_cell(this%prim_budget%igrid_sim%vE - this%pre_budget%igrid_sim%vE, this%pre_budget%igrid_sim%w)
+        !  this%budget_0(:,:,:,18) = this%budget_0(:,:,:,18) + (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC) * (this%pre_budget%igrid_sim%v)
+         this%budget_0(:,:,:,18) = this%budget_0(:,:,:,18) + this%multiply_Edges_interp_cell(this%pre_budget%igrid_sim%vE, this%prim_budget%igrid_sim%w - this%pre_budget%igrid_sim%w)
          this%budget_0(:,:,:,19) = this%budget_0(:,:,:,19) + (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC) * (this%pre_budget%igrid_sim%wC)
          
          ! STEP 5: SGS stresses (also viscous stress if finite reynolds number is being used)
@@ -583,8 +590,11 @@ module budgets_time_avg_deficit_mod
                                         *(this%prim_budget%igrid_sim%T - this%pre_budget%igrid_sim%T)
             this%budget_0(:,:,:,28) = this%budget_0(:,:,:,28) + (this%prim_budget%igrid_sim%v - this%pre_budget%igrid_sim%v) &
                                         *(this%prim_budget%igrid_sim%T - this%pre_budget%igrid_sim%T)
-            this%budget_0(:,:,:,29) = this%budget_0(:,:,:,29) + (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC) &
-                                        *(this%prim_budget%igrid_sim%T - this%pre_budget%igrid_sim%T)
+            ! this%budget_0(:,:,:,29) = this%budget_0(:,:,:,29) + (this%prim_budget%igrid_sim%wC - this%pre_budget%igrid_sim%wC) &
+            !                             *(this%prim_budget%igrid_sim%T - this%pre_budget%igrid_sim%T)
+            this%budget_0(:,:,:,29) = this%budget_0(:,:,:,29) + &
+                this%multiply_Edges_interp_cell(this%prim_budget%igrid_sim%TE - this%pre_budget%igrid_sim%TE, this%prim_budget%igrid_sim%w - this%pre_budget%igrid_sim%w)
+
             this%budget_0(:,:,:,30) = this%budget_0(:,:,:,30) + (this%prim_budget%igrid_sim%T - this%pre_budget%igrid_sim%T) &
                                         *(this%prim_budget%igrid_sim%T - this%pre_budget%igrid_sim%T)
         end if 
@@ -2221,4 +2231,13 @@ module budgets_time_avg_deficit_mod
          call transpose_y_to_x(this%prim_budget%igrid_sim%rbuffyC(:,:,:,1),fmultC,this%prim_budget%igrid_sim%gpC)
  
      end subroutine 
+
+    ! multiply on edge cells and interpolate to cell centers to reduce aliasing issues
+    function multiply_Edges_interp_cell(this, f1E, f2E) result(fmultC)
+        class(budgets_time_avg_deficit), intent(inout) :: this
+        real(rkind), dimension(this%prim_budget%igrid_sim%gpE%xsz(1),this%prim_budget%igrid_sim%gpE%xsz(2),this%prim_budget%igrid_sim%gpE%xsz(3)), intent(in) :: f1E,f2E
+        real(rkind), dimension(this%prim_budget%igrid_sim%gpC%xsz(1),this%prim_budget%igrid_sim%gpC%xsz(2),this%prim_budget%igrid_sim%gpC%xsz(3)) :: fmultC
+
+        call this%interp_Edge2Cell(f1E * f2E, fmultC)
+    end function
  end module 


### PR DESCRIPTION
When computing time-averaged budgets, fields such as $\langle u' w' \rangle$ suffer aliasing issues when $w$ is first interpolated to cell centers, then multiplied by $u$. Instead, $u$ should be interpolated to the cell edges, multiplied by $w$, then the product should be interpolated back to the cell centers. This reduces aliasing issues in computing, for example, total horizontal shear stress: 
<img width="600" height="750" alt="image" src="https://github.com/user-attachments/assets/d897c6d7-0449-4bcc-979c-bcb89de9e081" />
Note that the blue line (labeled "Cell edges") is not used in the code and was only dumped as a diagnostic for the product on the edge cells before interpolating back to the cell centers. The fixed code outputs the red lines, the previous code outputs the black lines. 

The aliasing issue also pops up in other center-edge product terms, for example $\langle w' \theta' \rangle$: 
<img width="601" height="750" alt="image" src="https://github.com/user-attachments/assets/e56f969a-ebe2-4337-93a4-d9d525d657e7" />

And also in the deficit budgets: 
<img width="1781" height="1144" alt="Pasted image 20250908012307" src="https://github.com/user-attachments/assets/995f1633-bc6b-4525-8719-ed48f1b3d02a" />

Not all of the terms are fixed in this PR. For example, the pressure transport term $\langle p' w' \rangle$ or the subgrid flux terms $\langle \tau_{i3} u_i \rangle$. These can be fixed in the same manner by moving multiplications to the edge cells with the `multiply_Edges_interp_cell` function, or by writing a new custom function that also interpolates cell -> edge -> multiply -> interpolate E2C. 