### PR TITLE
Bugfix for ADM kernel

### DIFF
--- a/src/incompressible/actuatorDisk_CT.F90
+++ b/src/incompressible/actuatorDisk_CT.F90
@@ -54,9 +54,10 @@ module actuatorDisk_CTMod
 
 contains
 
-subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG)
+subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
     class(actuatordisk_ct), intent(inout) :: this
     real(rkind), intent(in), dimension(:,:,:), target :: xG, yG, zG
+    real(rkind), intent(in) :: dx, dy, dz
     integer, intent(in) :: ActuatorDisk_ID
     character(len=*), intent(in) :: inputDir
     character(len=clen) :: tempname, fname
@@ -80,9 +81,9 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG)
     call tic()
     
     ! link grids and read inputs 
-    this%dx=xG(2,1,1)-xG(1,1,1)
-    this%dy=yG(1,2,1)-yG(1,1,1)
-    this%dz=zG(1,1,2)-zG(1,1,1)
+    this%dx=dx
+    this%dy=dy
+    this%dz=dz
     this%dV = this%dx*this%dy*this%dz
     this%xLoc = xLoc; this%yLoc = yLoc; this%zLoc = zLoc
     this%cT = cT; this%diam = diam; this%yaw = yaw

--- a/src/incompressible/actuatorDisk_filtered.F90
+++ b/src/incompressible/actuatorDisk_filtered.F90
@@ -69,9 +69,10 @@ module actuatorDisk_FilteredMod
 
 contains
 
-subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG)
+subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
     class(actuatorDisk_filtered), intent(inout) :: this
     real(rkind), intent(in), dimension(:,:,:), target :: xG, yG, zG
+    real(rkind), intent(in) :: dx, dy, dz
     integer, intent(in) :: ActuatorDisk_ID
     character(len=*), intent(in) :: inputDir
     character(len=clen) :: tempname, fname
@@ -97,9 +98,9 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG)
     call tic()
     
     ! link grids and read inputs 
-    this%dx=xG(2,1,1)-xG(1,1,1)
-    this%dy=yG(1,2,1)-yG(1,1,1)
-    this%dz=zG(1,1,2)-zG(1,1,1)
+    this%dx = dx
+    this%dy = dy
+    this%dz = dz
     this%dV = this%dx*this%dy*this%dz
     this%xLoc = xLoc; this%yLoc = yLoc; this%zLoc = zLoc
     this%cT = cT; this%diam = diam; this%yaw = yaw; this%tilt = tilt

--- a/src/incompressible/turbineMod.F90
+++ b/src/incompressible/turbineMod.F90
@@ -309,7 +309,7 @@ subroutine init(this, inputFile, gpC, gpE, spectC, spectE, cbuffyC, cbuffYE, cbu
          allocate(this%dynamicArray(this%nTurbines))  ! TODO make generic turbine and move this outside
 
          do i = 1, this%nTurbines
-             call this%turbArrayADM_fil(i)%init(turbInfoDir, i, mesh(:,:,:,1), mesh(:,:,:,2), mesh(:,:,:,3))
+             call this%turbArrayADM_fil(i)%init(turbInfoDir, i, mesh(:,:,:,1), mesh(:,:,:,2), mesh(:,:,:,3), dx, dy, dz)
              this%gamma(i) = this%turbArrayADM_fil(i)%yaw*pi/180.d0  ! stored in RADIANS  TODO - phase this out
              this%theta(i) = 0.d0  ! tilt angle
              
@@ -324,7 +324,7 @@ subroutine init(this, inputFile, gpC, gpE, spectC, spectE, cbuffyC, cbuffYE, cbu
         ! added ADM type 6 for pressure figure KSH 09/17/2023
         allocate (this%turbArrayADM_CT(this%nTurbines))
          do i = 1, this%nTurbines
-             call this%turbArrayADM_CT(i)%init(turbInfoDir, i, mesh(:,:,:,1), mesh(:,:,:,2), mesh(:,:,:,3))
+             call this%turbArrayADM_CT(i)%init(turbInfoDir, i, mesh(:,:,:,1), mesh(:,:,:,2), mesh(:,:,:,3), dx, dy, dz)
              this%gamma(i) = this%turbArrayADM_CT(i)%yaw*pi/180.d0  ! stored in RADIANS TODO - phase this out
              this%theta(i) = 0.d0
          end do


### PR DESCRIPTION
The ADM modules previously computed dx, dy, dz from the `mesh`, for example: 
```
dx = xG(2,1,1,)-xG(1,1,1)
```

However, a problem arises if the grid decomposition is chosen such that some grid chunks only have one point in any given dimension. Fortran does not raise an Index exception (at least, not on Stampede or Anvil) and dx (or dy, dz) will be set to zero, which will break the kernel. 

Easy solution: pass dx, dy, dz into the initialization function. Here, this is done for ADM type 5 and 6. 