### PR TITLE
Debug double outputs with budget on

### DIFF
--- a/setup/SetupEnv_Stampede3.sh
+++ b/setup/SetupEnv_Stampede3.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-module load cmake
+module load cmake/3.31.9
 module load intel impi
+module load fftw3/3.3.10
 
 CWD=`pwd`
 export COMPILER_ID=Intel
 export FC=mpiifort
 export CC=mpiicc
 export CXX=mpiicpc
-export FFTW_PATH=${CWD}/dependencies/fftw-3.3.10
+export FFTW_PATH=$TACC_FFTW3_DIR
 export DECOMP_PATH=${CWD}/dependencies/2decomp_fft
 export VTK_IO_PATH=${CWD}/dependencies/Lib_VTK_IO/build
 export HDF5_PATH=${CWD}/dependencies/hdf5-1.14.3/build

--- a/setup/SetupEnv_Stampede3.sh
+++ b/setup/SetupEnv_Stampede3.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
-module load cmake/3.31.9
+module load cmake
 module load intel impi
-module load fftw3/3.3.10
 
 CWD=`pwd`
 export COMPILER_ID=Intel
 export FC=mpiifort
 export CC=mpiicc
 export CXX=mpiicpc
-export FFTW_PATH=$TACC_FFTW3_DIR
+export FFTW_PATH=${CWD}/dependencies/fftw-3.3.10
 export DECOMP_PATH=${CWD}/dependencies/2decomp_fft
 export VTK_IO_PATH=${CWD}/dependencies/Lib_VTK_IO/build
 export HDF5_PATH=${CWD}/dependencies/hdf5-1.14.3/build

--- a/src/incompressible/actuatorDisk_filtered.F90
+++ b/src/incompressible/actuatorDisk_filtered.F90
@@ -405,7 +405,7 @@ subroutine sample_on_circle(diam, xcen, ycen, xloc, yloc, dx, dy)
 end subroutine
 
 ! Right hand side forcing term for the ADM
-subroutine get_RHS(this, u, v, w, rhsxvals, rhsyvals, rhszvals)
+subroutine get_RHS(this, u, v, w, rhsxvals, rhsyvals, rhszvals, budgetCall)
     class(actuatordisk_filtered), intent(inout) :: this
     real(rkind), dimension(this%nxLoc, this%nyLoc, this%nzLoc), intent(inout) :: rhsxvals, rhsyvals, rhszvals
     real(rkind), dimension(this%nxLoc, this%nyLoc, this%nzLoc), intent(in)    :: u, v, w

--- a/src/incompressible/actuatorDisk_filtered.F90
+++ b/src/incompressible/actuatorDisk_filtered.F90
@@ -409,10 +409,13 @@ subroutine get_RHS(this, u, v, w, rhsxvals, rhsyvals, rhszvals)
     class(actuatordisk_filtered), intent(inout) :: this
     real(rkind), dimension(this%nxLoc, this%nyLoc, this%nzLoc), intent(inout) :: rhsxvals, rhsyvals, rhszvals
     real(rkind), dimension(this%nxLoc, this%nyLoc, this%nzLoc), intent(in)    :: u, v, w
+    logical, intent(in), optional :: budgetCall
+
     real(rkind) :: yaw, tilt
     real(rkind) :: usp_sq, force, vface
     real(rkind), dimension(3,1) :: n=[1,0,0], tau=[0,1,0] !xn, Ft
     real(rkind), dimension(3,3) :: R, T
+    logical :: writeTurbineVals
 
     ! update yaw and tilt of the turbine
     if (.not. this%useDynamicYaw .and. (this%yaw - yaw*180.d0/pi)>1.d-8) then
@@ -461,8 +464,11 @@ subroutine get_RHS(this, u, v, w, rhsxvals, rhsyvals, rhszvals)
     rhszvals = rhszvals + force * n(3,1) * this%scalarSource
 
     if (allocated(this%powerTime)) then   ! check allocated so only one processor writes data
-    !        if((this%Am_I_Split .and. this%myComm_nrank==0) .or. (.not. this%Am_I_Split)) then
-        if (usp_sq /= 0.d0) then
+        ! turbine values should not write if get_RHS is being called for budget calculations
+        writeTurbineVals = .true.
+        if (present(budgetCall)) writeTurbineVals = (.not. budgetCall)
+
+        if ((writeTurbineVals) .and. (usp_sq /= 0.d0)) then
             this%powerTime(this%tInd) = this%get_power()
             this%uTime(this%tInd) = this%ut
             this%vTime(this%tInd) = vface

--- a/src/incompressible/igrid_files/timestepping_stuff.F90
+++ b/src/incompressible/igrid_files/timestepping_stuff.F90
@@ -540,24 +540,23 @@
           end if
       end if
 
-      if (this%vizDump_Schedule == 1) then
-           if (this%DumpThisStep) then
-              call message(2,"Performing a fixed timed visualization dump at time:", this%tsim)
-              call message(2,"This time step used a deltaT:",this%dt)
-              call this%dump_visualization_files()
-           end if 
-      else
-           if (mod(this%step,this%t_dataDump) == 0) then
-              call message(0,"Scheduled visualization dump.")
-              call this%dump_visualization_files()
-           end if
-      end if 
-
-
       if (forceWrite) then
-         call message(2,"Performing a forced visualization dump.")
-         call this%dump_visualization_files()
-      end if
+
+        call message(0,"Performing a forced visualization dump.")
+        call this%dump_visualization_files()
+
+      else if (this%vizDump_Schedule == 1  .and. this%DumpThisStep) then
+
+        call message(0,"Performing a fixed timed visualization dump at time:", this%tsim)
+        call message(2,"This time step used a deltaT:",this%dt)
+        call this%dump_visualization_files()
+
+      else if (this%vizDump_Schedule /= 1 .and. mod(this%step, this%t_dataDump) == 0)
+
+        call message(0,"Scheduled visualization dump.")
+        call this%dump_visualization_files()
+        
+      end if 
 
       if (this%initspinup) then
        if (this%tsim > this%Tstop_initspinup) then

--- a/src/incompressible/igrid_files/timestepping_stuff.F90
+++ b/src/incompressible/igrid_files/timestepping_stuff.F90
@@ -540,12 +540,7 @@
           end if
       end if
 
-      if (forceWrite) then
-
-        call message(0,"Performing a forced visualization dump.")
-        call this%dump_visualization_files()
-
-      else if (this%vizDump_Schedule == 1  .and. this%DumpThisStep) then
+      if (this%vizDump_Schedule == 1  .and. this%DumpThisStep) then
 
         call message(0,"Performing a fixed timed visualization dump at time:", this%tsim)
         call message(2,"This time step used a deltaT:",this%dt)
@@ -554,6 +549,11 @@
       else if (this%vizDump_Schedule /= 1 .and. mod(this%step, this%t_dataDump) == 0) then
 
         call message(0,"Scheduled visualization dump.")
+        call this%dump_visualization_files()
+
+      else if (forceWrite) then
+
+        call message(0,"Performing a forced visualization dump.")
         call this%dump_visualization_files()
         
       end if 

--- a/src/incompressible/igrid_files/timestepping_stuff.F90
+++ b/src/incompressible/igrid_files/timestepping_stuff.F90
@@ -551,7 +551,7 @@
         call message(2,"This time step used a deltaT:",this%dt)
         call this%dump_visualization_files()
 
-      else if (this%vizDump_Schedule /= 1 .and. mod(this%step, this%t_dataDump) == 0)
+      else if (this%vizDump_Schedule /= 1 .and. mod(this%step, this%t_dataDump) == 0) then
 
         call message(0,"Scheduled visualization dump.")
         call this%dump_visualization_files()

--- a/src/incompressible/turbineMod.F90
+++ b/src/incompressible/turbineMod.F90
@@ -785,7 +785,7 @@ subroutine getForceRHS(this, dt, u, v, wC, urhs, vrhs, wrhs, newTimeStep, inst_h
                         call this%dynamicArray(i)%time_advance(dt)
                     endif
 
-                    call this%turbArrayADM_fil(i)%get_RHS(u,v,wC,this%fx,this%fy,this%fz)
+                    call this%turbArrayADM_fil(i)%get_RHS(u,v,wC,this%fx,this%fy,this%fz, budgetCall)
                end do
            case (6)
                do i = 1, this%nTurbines


### PR DESCRIPTION
Previously, when budgets were turned on, the values within the output `.pow` and `.vel` files were repeated. This was happening because within the `get_RHS` function, values were being added to the list that is later printed out:

```
this%powerTime(this%tInd) = this%get_power()
this%uTime(this%tInd) = this%ut
this%vTime(this%tInd) = vface
```

Since `get_RHS` is called twice, both for the general time step functionality and for the budget, values were getting added to these lists twice per time step. I used the `budgetCall` flag, added in #7, to ensure that values are not added to the lists twice. 

I also cleaned up the data visualization call to add the `forceDump` option to the if/else block so that it wasn't being called twice on a force dump time step.

I will reset the setup environment file before I merge and add a example below. 