### PR TITLE
Increasing ADM sampling resolution parameter to fix kernel bug

### DIFF
--- a/src/incompressible/actuatorDisk_filtered.F90
+++ b/src/incompressible/actuatorDisk_filtered.F90
@@ -21,7 +21,7 @@ module actuatorDisk_FilteredMod
         integer :: xLoc_idx, ActutorDisk_T2ID, tInd = 1
         real(rkind) :: yaw, tilt, ut, powerBaseline, hubDirection
         real(rkind) :: xLoc, yLoc, zLoc, dx, dy, dz, dV
-        real(rkind) :: diam, cT, pfactor, normfactor, OneBydelSq, Cp, thick, npts
+        real(rkind) :: diam, cT, pfactor, normfactor, OneBydelSq, Cp, thick, npts, upsample_fact
         real(rkind) :: uface = zero, vface = zero, wface = zero  ! LES velocity, disk-averaged
         real(rkind) :: uturb, vturb, wturb  ! turbine motion vector
 
@@ -30,7 +30,7 @@ module actuatorDisk_FilteredMod
         logical :: useDynamicYaw, quickDecomp
 
         ! Grid Info
-        integer :: nxLoc, nyLoc, nzLoc 
+        integer :: nxLoc, nyLoc, nzLoc
         real(rkind) :: delta, M  ! Shapiro smearing size, corr. factor M<1
         real(rkind), dimension(:), allocatable :: xline, yline, zline
         real(rkind), dimension(:,:,:), pointer :: xG, yG, zG
@@ -77,7 +77,7 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
     character(len=*), intent(in) :: inputDir
     character(len=clen) :: tempname, fname
     integer :: ioUnit, ierr
-    real(rkind) :: xLoc=1.d0, yLoc=1.d0, zLoc=0.1d0
+    real(rkind) :: xLoc=1.d0, yLoc=1.d0, zLoc=0.1d0, upsample_fact=two
     real(rkind) :: diam=0.08d0, cT=0.65d0, yaw=0.d0, tilt=0.d0, h  !, Cp = 0.3
     real(rkind) :: thickness=1.5d0, filterWidth=0.5, time2initialize=0.d0
     logical :: useCorrection=.true., useDynamicYaw=.false., quickDecomp=.false., use_h=.false.
@@ -105,6 +105,7 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
     this%xLoc = xLoc; this%yLoc = yLoc; this%zLoc = zLoc
     this%cT = cT; this%diam = diam; this%yaw = yaw; this%tilt = tilt
     this%ut = 1.d0!; this%Cp = Cp
+    this%upsample_fact = upsample_fact
 
     this%uturb = zero; this%vturb = zero; this%wturb = zero
     
@@ -159,7 +160,7 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
     end if
 
     ! Get (unrotated) turbine location points
-    call sample_on_circle(this%diam, this%yLoc, this%zLoc, this%ys, this%zs, this%dy, this%dz)
+    call sample_on_circle(this%diam, this%yLoc, this%zLoc, this%ys, this%zs, this%dy, this%dz, this%upsample_fact)
     this%npts = size(this%ys,1)
     call message(1, "NUMBER OF POINTS: ", this%npts)
     allocate(this%xs(size(this%ys)))
@@ -177,7 +178,7 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
         call message(2, "Using Dynamic Yaw")
     else
         call message(2, "Using static turbine.")
-        call this%redraw()  ! get_weights(this) 
+        call this%get_weights()
     end if
     
     call message(2, "Smearing grid parameter, Delta", this%delta)
@@ -348,10 +349,10 @@ subroutine get_weights(this)
 end subroutine
 
 ! sample a circle with points spaced dx, dy apart and centered at xcen, ycen
-subroutine sample_on_circle(diam, xcen, ycen, xloc, yloc, dx, dy)
+subroutine sample_on_circle(diam, xcen, ycen, xloc, yloc, dx, dy, upsample_fact)
     use gridtools, only: linspace
-    real(rkind), intent(in) :: diam, xcen, ycen, dx, dy
-    real(rkind) :: R
+    real(rkind), intent(in) :: diam, xcen, ycen, dx, dy, upsample_fact
+    real(rkind) :: R, dxi
     integer, dimension(:), allocatable :: tag
     real(rkind), dimension(:), allocatable :: xline, yline
     real(rkind), dimension(:), allocatable, intent(out) :: xloc, yloc
@@ -359,7 +360,8 @@ subroutine sample_on_circle(diam, xcen, ycen, xloc, yloc, dx, dy)
     integer :: idx, i, j, nsz, iidx, nx_per_R, ny_per_R, nx, ny, np
     
     R = diam/two
-    nx_per_R = ceiling(R/dx); ny_per_R = ceiling(R/dy)
+    dxi = min(dx, dy) / upsample_fact  ! upsample the resolution of the LES grid
+    nx_per_R = ceiling(R/dxi); ny_per_R = ceiling(R/dxi)
     nx = nx_per_R*2 + 1
     ny = ny_per_R*2 + 1
     np = nx*ny  ! total number of points
@@ -370,19 +372,12 @@ subroutine sample_on_circle(diam, xcen, ycen, xloc, yloc, dx, dy)
     ! initialize linearly-spaced arrays 
     ! this is necessary to do independently of the grid xG, yG, zG 
     ! because parallelization splits the grid up
-    xline = (/(i, i=-nx_per_R, nx_per_R)/) * dx
-    yline = (/(i, i=-ny_per_R, ny_per_R)/) * dy
+    xline = (/(i, i=-nx_per_R, nx_per_R)/) * dxi
+    yline = (/(i, i=-ny_per_R, ny_per_R)/) * dxi
     
     ! reshapes xline, yline: 
-!    xtmp = reshape(spread(xline, 1, ny), [np])
-!    ytmp = reshape(spread(yline, 2, nx), [np])  ! why doesn't reshape() work? 
-    idx = 1
-    do j = 1,ny
-        do i = 1,nx
-            xtmp(idx) = xline(i); ytmp(idx) = yline(j)
-            idx = idx + 1
-        end do 
-    end do
+    xtmp = reshape(spread(xline, 2, ny), [np])  ! Spread along dim 2, then flatten
+    ytmp = reshape(spread(yline, 1, nx), [np])  ! Spread along dim 1, then flatten
     rtmp = sqrt(xtmp**2 + ytmp**2) 
     tag = 0
     where (rtmp < R) 
@@ -555,7 +550,7 @@ subroutine redraw(this)
     class(actuatordisk_filtered), intent(inout) :: this
 
     ! (re)sample points, this is quick
-    call sample_on_circle(this%diam, this%yloc, this%zloc, this%ys, this%zs, this%dy, this%dz)
+    call sample_on_circle(this%diam, this%yloc, this%zloc, this%ys, this%zs, this%dy, this%dz, this%upsample_fact)
     this%npts = size(this%ys, 1)  
     this%xs = this%xloc
     


### PR DESCRIPTION
Small fix to this one...

Originally, in ADM type 5, the control points to assemble the forcing kernel (heaviside function convolved with a Gaussian convolution) were sampled with the native grid resolution dy, dz. This produced some strange-looking octagonal turbines for low grid resolutions (top subfigure below). Now there is an additional flag in `actuatorDisk_filtered` called `upsample_fact` which defaults to two: the forcing kernel is assembled with control points at twice the LES grid resolution. This makes a more "circular" turbine (middle subfigure): 
<img width="626" height="855" alt="image" src="https://github.com/user-attachments/assets/4017c184-a397-4e0a-8053-e2ed36ee7919" />
The bottom subfigure shows the difference (relative magnitude is important, not absolute magnitude). 

As an aside, the "fast" convolution assembly with the domain indexing enables the upsampled control points. When assembling the convolution integral on the full LES grid, quadrupling the number of control points ends up signficantly slowing down the code, especially if the kernel needs to be rebuilt (in dynamic yaw or with floating dynamics, see [here](https://github.com/Howland-Lab/PadeOps/pull/8)). With the fast kernel build, the added control points don't seem to increase the cost significantly. 

The `upsample_fact` parameter is fixed at 2.0. This could be passed into the namelist (it is a parameter in `init`), but I can't think of a reason that passing one in would be particularly beneficial. Could be implemented in the future if useful. 

Finally, a note on the old "global" convolution assembly... there seems to be an issue with the kernel building depending on the processor decomposition. This is fixed in the "fast" ADM kernel (not entirely sure why). It is also fixed by increasing the sampling resolution. I'm not entirely sure what is causing it, but here is a screenshot of the behavior: 
<img width="626" height="855" alt="image" src="https://github.com/user-attachments/assets/0b349b9e-437a-4ce8-8d53-48dedc4a1d31" />

I had a reproducible version of this error, but now I've lost the specific code version that it occurred in. Other details: 
- $256^3$ box with grid cells $(\Delta_x, \Delta_y, \Delta_z) = (0.1, 0.05, 0.05)D$
- Uniform, laminar inflow
- Run on 108 processors
- Two processor decompositions: (12 x 9) and (4 x 27)
