### PR TITLE
Fatal error when any pencil thickness = 1 and turbines are used

### DIFF
--- a/src/incompressible/igrid.F90
+++ b/src/incompressible/igrid.F90
@@ -542,6 +542,11 @@ contains
             call decomp_info_init(nx, ny, nz, this%gpC)    
         end if
 
+        if (any(this%gpC%xsz == 1) .or. any(this%gpC%ysz == 1) .or. any(this%gpC%zsz == 1))then
+            if(this%useWindTurbines)then
+                call gracefulExit("Pencil thickness = 1 detected in gpC. Wind turbine module may fail.", 901)
+            end if
+        end if
        call decomp_info_init(nx,ny,nz+1,this%gpE)
        
        if (this%useSystemInteractions) then


### PR DESCRIPTION
I added a fatal error message to igrid.F90 when the domain decomposition (either manual or automatic) result in a single-cell pencil in any direction. This will cause the simulation to fail if wind turbines are used. The reason of faliure is in the actuatorDisk_filtered.F90 file, specifically here:
```
! link grids and read inputs 
this%dx=xG(2,1,1)-xG(1,1,1)
this%dy=yG(1,2,1)-yG(1,1,1)
this%dz=zG(1,1,2)-zG(1,1,1)
```
If the y or z pencils have a single cell, the second or third lines should actually give an error because it would be accessing a location out of bound, but intel compiler returns a zero instead (for yG(1,2,1) or zG(1,1,2)). This yields a zero dy or dz. If, for example, dy=0 (which was in my case), the grid points marked as within the rotor's disk will be selected from points generated along a line rather than selecting from a rectangle. 

When the simulation starts with this setup, all of the turbine's thrust is distributed along a few number of points along a line which breaks the simulation (NANs appear). I am not sure if it breaks because of high force/point or during the Gaussian kernel mapping onto the 1D line points. Either way the simulation breaks.

I added this fatal error message to stop the simulation early on if turbines are being used with a single-cell pencil. If this happens, maybe select a specific decomposition (set prow & pcol manually) rather than using the auto mode (prow=pcol=0).

