### PR TITLE
Cleanup MPI stuff in actuator disk module

### DIFF
--- a/src/incompressible/actuatorDisk_filtered.F90
+++ b/src/incompressible/actuatorDisk_filtered.F90
@@ -561,10 +561,10 @@ subroutine get_RHS(this, u, v, w, rhsxvals, rhsyvals, rhszvals, budgetCall)
     real(rkind), dimension(3,3) :: R, T
     logical :: writeTurbineVals
 
-    ! update yaw and tilt of the turbine
-    if (.not. this%useDynamicYaw .and. (this%yaw - yaw*180.d0/pi)>1.d-8) then
-        call GracefulExit("Turbine prescribed yaw changed, but useDynamicYaw is OFF", 423)
-    end if
+    ! MOVED to DynamicTurbine module - can remove this
+    ! if (.not. this%useDynamicYaw .and. (this%yaw - yaw*180.d0/pi)>1.d-8) then
+    !     call GracefulExit("Turbine prescribed yaw changed, but useDynamicYaw is OFF", 423)
+    ! end if
 
     if (.not. this%Am_I_Active) return
     yaw = this%yaw * pi/180.d0

--- a/src/incompressible/actuatorDisk_filtered.F90
+++ b/src/incompressible/actuatorDisk_filtered.F90
@@ -81,7 +81,15 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
     real(rkind) :: diam=0.08d0, cT=0.65d0, yaw=0.d0, tilt=0.d0, h  !, Cp = 0.3
     real(rkind) :: thickness=1.5d0, filterWidth=0.5, time2initialize=0.d0
     logical :: useCorrection=.true., useDynamicYaw=.false., quickDecomp=.false., use_h=.false.
-
+    real(rkind) :: rcutSqr
+    integer :: i, j, k
+    real(rkind) :: dxp, dyp, dzp
+    integer :: world_rank, is_active, nact
+    integer, allocatable :: actives(:)
+    character(len=4) :: turbindex
+    character(len=2048) :: active_ranks
+    character(len=16) :: tmp
+    
     ! Read input file for this turbine    
     namelist /ACTUATOR_DISK/ xLoc, yLoc, zLoc, diam, cT, yaw, tilt, filterWidth, useCorrection, &
                              useDynamicYaw, thickness, quickDecomp, use_h
@@ -93,7 +101,8 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
     open(unit=ioUnit, file=trim(fname), form='FORMATTED', action="read")
     read(unit=ioUnit, NML=ACTUATOR_DISK)
     close(ioUnit)
-    
+
+    call MPI_COMM_RANK(MPI_COMM_WORLD, world_rank, ierr)
     call message(0, "Initializing Actuator Disk (ADM Type=5) number", ActuatorDisk_ID)
     call tic()
     
@@ -119,28 +128,6 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
     this%xG => xG; this%yG => yG; this%zG => zG
     this%xLine = xG(:,1,1); this%yLine = yG(1,:,1); this%zLine = zG(1,1,:)
 
-    ! allocate memory buffers
-    allocate(this%rbuff(this%nxLoc, this%nyLoc, this%nzLoc))
-    allocate(this%blanks(this%nxLoc, this%nyLoc, this%nzLoc))
-    allocate(this%speed(this%nxLoc, this%nyLoc, this%nzLoc))
-    allocate(this%scalarsource(this%nxLoc, this%nyLoc, this%nzLoc))
-    
-    ! copied from ADM T2
-    this%Am_I_Split = .TRUE. ! TODO: Fix me later by flagging where the turbine is
-    if (this%Am_I_Split) then
-        call MPI_COMM_SPLIT(mpi_comm_world, this%color, nrank, this%mycomm, ierr)
-        call MPI_COMM_RANK(this%mycomm, this%myComm_nrank, ierr) 
-        call MPI_COMM_SIZE(this%mycomm, this%myComm_nproc, ierr)
-    end if 
-    
-    ! this ensures that only ONE turbine is keeping track of power and writing to disk
-    if((this%Am_I_Split .and. this%myComm_nrank==0) .or. (.not. this%Am_I_Split)) then
-!        write(*,*) "Only one allocated? YES/NO"
-        allocate(this%powerTime(1000000))  
-        allocate(this%uTime(1000000))  
-        allocate(this%vTime(1000000))
-    end if
-
     ! Set thickness
     this%thick = thickness*this%dx
     if (use_h) then
@@ -157,6 +144,88 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
         call message(1, "ADM: using quick decomposition in x")
     else
         call message(1, "ADM: using full kernel integration")
+    end if
+
+    ! Decide if the turbine is active on the current rank
+    ! If any point is within rcut from the turbine, this turbine is active on current rank
+    rcutSqr = (this%diam/2) + 3.0d0*this%delta + 0.5d0*max(this%dx, this%dy, this%dz)
+    rcutSqr = rcutSqr*rcutSqr
+    this%Am_I_Active = .false.
+    do k = 1, this%nzLoc
+        do j = 1, this%nyLoc
+            do i = 1, this%nxLoc
+                dxp = this%xG(i,j,k) - this%xLoc
+                dyp = this%yG(i,j,k) - this%yLoc
+                dzp = this%zG(i,j,k) - this%zLoc
+                if (dxp*dxp + dyp*dyp + dzp*dzp <= rcutSqr) then
+                    this%Am_I_Active = .true.
+                    exit
+                end if
+            end do
+            if (this%Am_I_Active) exit
+        end do
+        if (this%Am_I_Active) exit
+    end do
+    
+    ! Set the color. Now the split holds ranks that have Am_I_Active = .true.
+    ! Need to pass the local comm to p_sum later (was missing and was summing over MPI_COMM_WORLD instead)
+    if(this%Am_I_Active) then
+        this%color = ActuatorDisk_ID
+    else
+        this%color = MPI_UNDEFINED
+        this%myComm = MPI_COMM_NULL
+    end if
+
+    ! Gather the indices of ranks where current turbine is active
+    is_active = merge(1, 0, this%Am_I_Active)
+    call gather_active_ranks_all(is_active, actives, nact, MPI_COMM_WORLD)
+    write(turbindex,'(I4.4)') ActuatorDisk_ID
+    active_ranks=''
+    if(nact>0)then
+        do i = 1, nact
+            write(tmp, '(I0)') actives(i)
+            active_ranks = trim(active_ranks)//trim(tmp)//'-'
+        end do    
+        call message(1, 'Active ranks of turbine '//trim(turbindex)//' are '//trim(active_ranks))
+    else
+        call message(1, 'No active ranks for turbine '//trim(turbindex))
+    end if
+    if(allocated(actives)) deallocate(actives)
+
+    ! If the turbine is active on a single rank, no need for MPI_COMM_SPLIT
+    this%Am_I_Split = nact > 1
+    this%myComm = MPI_COMM_NULL
+    this%myComm_nrank = -1
+    this%myComm_nproc = 0
+    if (this%Am_I_Split) then
+        call MPI_COMM_SPLIT(MPI_COMM_WORLD, this%color, world_rank, this%mycomm, ierr)
+        if (this%color /= MPI_UNDEFINED) then
+            call MPI_COMM_RANK(this%mycomm, this%myComm_nrank, ierr)
+            call MPI_COMM_SIZE(this%mycomm, this%myComm_nproc, ierr)
+        end if
+    end if 
+
+    ! Safe guard only
+    if (.not. this%Am_I_Split .and. this%Am_I_Active) then
+        this%myComm = MPI_COMM_SELF
+        this%myComm_nrank = 0
+        this%myComm_nproc = 1
+    end if
+
+    ! allocate memory buffers
+    if(this%Am_I_Active)then
+        allocate(this%rbuff(this%nxLoc, this%nyLoc, this%nzLoc))
+        !allocate(this%blanks(this%nxLoc, this%nyLoc, this%nzLoc))
+        !allocate(this%speed(this%nxLoc, this%nyLoc, this%nzLoc))
+        allocate(this%scalarsource(this%nxLoc, this%nyLoc, this%nzLoc))    
+        this%scalarsource = zero
+        
+        ! this ensures that only ONE turbine is keeping track of power and writing to disk
+        if((this%Am_I_Split .and. this%myComm_nrank==0) .or. (.not. this%Am_I_Split)) then
+            allocate(this%powerTime(10000))  
+            allocate(this%uTime(10000))  
+            allocate(this%vTime(10000))
+        end if
     end if
 
     ! Get (unrotated) turbine location points
@@ -178,7 +247,7 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
         call message(2, "Using Dynamic Yaw")
     else
         call message(2, "Using static turbine.")
-        call this%get_weights()
+        if(this%Am_I_Active) call this%get_weights()
     end if
     
     call message(2, "Smearing grid parameter, Delta", this%delta)
@@ -187,16 +256,84 @@ subroutine init(this, inputDir, ActuatorDisk_ID, xG, yG, zG, dx, dy, dz)
     call message(3, "x = ", this%xLoc)
     call message(3, "y = ", this%yLoc)
     call message(3, "z = ", this%zLoc)
-    call toc(mpi_comm_world, time2initialize)
+    if(.not. this%Am_I_Active)then
+        ! Deallocate
+        if(allocated(this%xs)) deallocate(this%xs)
+        if(allocated(this%ys)) deallocate(this%ys)
+        if(allocated(this%zs)) deallocate(this%zs)
+        if(allocated(this%xline)) deallocate(this%xline)
+        if(allocated(this%yline)) deallocate(this%yline)
+        if(allocated(this%zline)) deallocate(this%zline)
+        nullify(this%xG, this%yG, this%zG)
+    end if
+    call toc(MPI_COMM_WORLD, time2initialize)
     call message(2, "Time (seconds) to initialize", time2initialize)
 end subroutine 
 
+subroutine gather_active_ranks_all(is_active, active_ranks, nactive, comm)
+    use mpi
+    implicit none
+    integer, intent(in) :: is_active                 ! 0 or 1 on each rank
+    integer, intent(in) :: comm                      ! typically MPI_COMM_WORLD
+    integer, allocatable, intent(out) :: active_ranks(:)  ! allocated on ALL ranks
+    integer, intent(out) :: nactive                  ! valid on ALL ranks
+    integer :: ierr, rank, nproc, i
+    integer, allocatable :: flags(:)
+
+    call MPI_Comm_rank(comm, rank, ierr)
+    call MPI_Comm_size(comm, nproc, ierr)
+    allocate(flags(nproc))
+
+    ! Everyone gets the activity flag from everyone
+    call MPI_Allgather(is_active, 1, MPI_INTEGER, flags, 1, MPI_INTEGER, comm, ierr)
+
+    ! Count and build the list (world ranks are 0-based)
+    nactive = 0
+    do i = 1, nproc
+        if (flags(i) /= 0) nactive = nactive + 1
+    end do
+
+    if(nactive > 0)then
+        allocate(active_ranks(nactive))
+        nactive = 0
+        do i = 1, nproc
+            if (flags(i) /= 0) then
+                nactive = nactive + 1
+                active_ranks(nactive) = i - 1
+            end if
+        end do
+    end if
+    deallocate(flags)
+end subroutine gather_active_ranks_all
+
 subroutine destroy(this)
     class(actuatordisk_filtered), intent(inout) :: this
+    integer :: ierr
 
-    deallocate(this%rbuff, this%blanks, this%speed, this%scalarSource) 
+    if(allocated(this%rbuff)) deallocate(this%rbuff)
+    if(allocated(this%blanks)) deallocate(this%blanks)
+    if(allocated(this%speed)) deallocate(this%speed)
+    if(allocated(this%scalarSource)) deallocate(this%scalarSource)
+    if(allocated(this%powerTime)) deallocate(this%powerTime)
+    if(allocated(this%uTime))     deallocate(this%uTime)
+    if(allocated(this%vTime))     deallocate(this%vTime)
+    if(allocated(this%xs)) deallocate(this%xs)
+    if(allocated(this%ys)) deallocate(this%ys)
+    if(allocated(this%zs)) deallocate(this%zs)
+    if(allocated(this%xLine)) deallocate(this%xLine)
+    if(allocated(this%yLine)) deallocate(this%yLine)
+    if(allocated(this%zLine)) deallocate(this%zLine)
+
+    ! Free communicator
+    if (this%myComm /= MPI_COMM_NULL .and. &
+        this%myComm /= MPI_COMM_WORLD .and. &
+        this%myComm /= MPI_COMM_SELF) then
+        call MPI_COMM_FREE(this%myComm, ierr)
+        this%myComm = MPI_COMM_NULL
+    end if
+
     nullify(this%xG, this%yG, this%zG)
-end subroutine 
+end subroutine
 
 ! Convolution in x (streamwise) direction
 subroutine get_R1(this, R1) 
@@ -301,8 +438,8 @@ subroutine get_R(this)
             do j = j1, j2
                 do i = i1, i2
                     rsq = (this%xG(i,j,l) - xi(k))**2 + &
-                                        (this%yG(i,j,l) - yi(k))**2 + &
-                                        (this%zG(i,j,l) - zi(k))**2
+                          (this%yG(i,j,l) - yi(k))**2 + &
+                          (this%zG(i,j,l) - zi(k))**2
                     this%scalarsource(i,j,l) = this%scalarsource(i,j,l) + C1 * exp(coef * rsq)
                 end do
             end do
@@ -317,7 +454,9 @@ subroutine get_weights(this)
     real(rkind), dimension(this%nyLoc, this%nzLoc) :: R2
     real(rkind), dimension(this%nxLoc) :: R1
     real(rkind), dimension(this%nxLoc, this%nyLoc, this%nzLoc) :: R
-        
+    real(rkind) :: smax
+
+    this%scalarsource = zero        
     if ((abs(this%yaw) < 1e-3) .and. (abs(this%tilt) < 1e-3)) then
         if (this%quickDecomp) then
             !aligned with the x-direction, use the "quick" kernel creation
@@ -340,12 +479,21 @@ subroutine get_weights(this)
     end if
      
     ! minimum threshold tolerance
-    where (this%scalarsource < 1.d-10)
+    if(this%Am_I_Split)then
+        smax = p_maxval(this%scalarsource, this%mycomm)
+    else
+        smax = MAXVAL(this%scalarsource)
+    end if
+    where (this%scalarsource < 1.d-12 * smax)
         this%scalarsource = 0
     end where
 
     ! normalize so R integrates to 1 exactly
-    this%scalarsource = this%scalarsource / (p_sum(this%scalarsource)*this%dV) 
+    if(this%Am_I_Split)then
+        this%scalarsource = this%scalarsource / (p_sum(this%scalarsource, this%mycomm)*this%dV)
+    else
+        this%scalarsource = this%scalarsource / (SUM(this%scalarsource)*this%dV)
+    end if 
 end subroutine
 
 ! sample a circle with points spaced dx, dy apart and centered at xcen, ycen
@@ -357,7 +505,7 @@ subroutine sample_on_circle(diam, xcen, ycen, xloc, yloc, dx, dy, upsample_fact)
     real(rkind), dimension(:), allocatable :: xline, yline
     real(rkind), dimension(:), allocatable, intent(out) :: xloc, yloc
     real(rkind), dimension(:), allocatable :: xtmp, ytmp, rtmp
-    integer :: idx, i, j, nsz, iidx, nx_per_R, ny_per_R, nx, ny, np
+    integer :: idx, i, nsz, iidx, nx_per_R, ny_per_R, nx, ny, np
     
     R = diam/two
     dxi = min(dx, dy) / upsample_fact  ! upsample the resolution of the LES grid
@@ -397,6 +545,7 @@ subroutine sample_on_circle(diam, xcen, ycen, xloc, yloc, dx, dy, upsample_fact)
 
     xloc = xloc + xcen; yloc = yloc + ycen 
     deallocate(xtmp, ytmp, rtmp, tag)  ! deallocate temporary variables
+    deallocate(xline, yline)
 end subroutine
 
 ! Right hand side forcing term for the ADM
@@ -417,6 +566,7 @@ subroutine get_RHS(this, u, v, w, rhsxvals, rhsyvals, rhszvals, budgetCall)
         call GracefulExit("Turbine prescribed yaw changed, but useDynamicYaw is OFF", 423)
     end if
 
+    if (.not. this%Am_I_Active) return
     yaw = this%yaw * pi/180.d0
     tilt = this%tilt * pi/180.d0
 
@@ -438,18 +588,20 @@ subroutine get_RHS(this, u, v, w, rhsxvals, rhsyvals, rhszvals, budgetCall)
     ! vface = p_sum(this%scalarSource*(u*tau(1,1) + v*tau(2,1) + w*tau(3,1)))*this%dV
 
     ! NEW method -- requires more p_sum but results in a vector
-    this%uface = p_sum(this%scalarSource * u) * this%dV
-    this%vface = p_sum(this%scalarSource * v) * this%dV
-    this%wface = p_sum(this%scalarSource * w) * this%dV
+    ! Need to pass the local comm to p_sum
+    ! Also avoid forcing the compiler to create temperorary arrays
+    if(this%Am_I_Split)then
+        this%rbuff = this%scalarSource*u; this%uface = p_sum(this%rbuff, this%mycomm) * this%dV
+        this%rbuff = this%scalarSource*v; this%vface = p_sum(this%rbuff, this%mycomm) * this%dV
+        this%rbuff = this%scalarSource*w; this%wface = p_sum(this%rbuff, this%mycomm) * this%dV
+    else
+        this%rbuff = this%scalarSource*u; this%uface = SUM(this%rbuff) * this%dV
+        this%rbuff = this%scalarSource*v; this%vface = SUM(this%rbuff) * this%dV
+        this%rbuff = this%scalarSource*w; this%wface = SUM(this%rbuff) * this%dV
+    end if
     this%ut = this%M * ((this%uface - this%uturb) * n(1,1) + (this%vface - this%vturb) * n(2,1) + (this%wface - this%wturb) * n(3,1))
     vface = ((this%uface - this%uturb) * tau(1,1) + (this%vface - this%vturb) * tau(2,1) + (this%wface - this%wturb) * tau(3,1))
     
-    ! call message(1, 'DEBUG ActuatorDisk: this%ut', this%ut)
-    ! TODO: May need to update yaw before calling get_weights()
-    ! if (this%useDynamicYaw) then
-    !     call this%get_weights() 
-    ! end if
-
     ! Mean speed at the turbine, corrected with factor M
     usp_sq = (this%ut)**2
     force = -0.5d0*this%cT*(pi*(this%diam**2)/4.d0)*usp_sq

--- a/src/utilities/reductions.F90
+++ b/src/utilities/reductions.F90
@@ -12,7 +12,7 @@ module reductions
     external :: MPI_ALLREDUCE
 
     interface P_MAXVAL
-        module procedure P_MAXVAL_arr4, P_MAXVAL_arr3, P_MAXVAL_arr2, P_MAXVAL_sca, P_MAXVAL_int, P_MAXVAL_int_locComm
+        module procedure P_MAXVAL_arr4, P_MAXVAL_arr3, P_MAXVAL_arr3_locComm, P_MAXVAL_arr2, P_MAXVAL_sca, P_MAXVAL_int, P_MAXVAL_int_locComm
     end interface
 
     interface P_MINVAL
@@ -60,6 +60,18 @@ contains
 
         mymax = MAXVAL(x)
         call MPI_Allreduce(mymax, maximum, 1, mpirkind, MPI_MAX, MPI_COMM_WORLD, ierr)
+
+    end function
+
+    function P_MAXVAL_arr3_locComm(x, locCommWorld) result(maximum)
+        real(rkind), dimension(:,:,:), intent(in) :: x
+        integer, intent(in) :: locCommWorld
+        real(rkind) :: maximum
+        real(rkind) :: mymax
+        integer :: ierr
+
+        mymax = MAXVAL(x)
+        call MPI_Allreduce(mymax, maximum, 1, mpirkind, MPI_MAX, locCommWorld, ierr)
 
     end function
 


### PR DESCRIPTION
> **Disclaimer**
> This description has been edited by ChatGPT based on an earlier human version

## Summary

While investigating potential MPI-related issues in the filtered actuator disk implementation, I identified incorrect handling of `this%color` in `actuatorDisk_filtered.F90`.

The variable `this%color` is used in `MPI_COMM_SPLIT` to create a sub-communicator containing only the ranks on which a given turbine is active (i.e., ranks whose local subdomain intersects the turbine influence region). However, `this%color` was not explicitly initialized before being used.

Depending on compiler behaviour, this led to two possible scenarios.

---

## Observed Behaviour

### Case 1 — Compiler initializes to zero

With the Intel compiler, uninitialized integers are implicitly set to zero. As a result:

- All ranks had `this%color = 0`.
- `MPI_COMM_SPLIT` created a communicator identical to `MPI_COMM_WORLD`.
- `this%mycomm` became a duplicate of `MPI_COMM_WORLD`.

Although this did not affect correctness (because `p_sum` and `p_maxval` were performed on `MPI_COMM_WORLD`), it resulted in unnecessary global communication rather than restricting reductions to the subset of active ranks.

---

### Case 2 — `this%color` contains random memory

If `this%color` contains undefined memory:

- Each rank may pass a different value to `MPI_COMM_SPLIT`.
- `MPI_COMM_WORLD` may be split into as many sub-communicators as there are ranks.
- Each rank may become the sole member of its own communicator.
- Each rank then identifies itself as local rank 0 (`this%myComm_nrank == 0`).

This leads to:

- Redundant allocation of large arrays (since each rank believes it is rank 0 of its communicator).
- Unnecessary memory usage.

Additionally, reductions in `p_sum` and `p_maxval` were still performed over `MPI_COMM_WORLD` rather than `this%mycomm`. In this pathological case, this behaviour unintentionally prevented incorrect physics: had reductions been restricted to single-rank communicators, the disk-averaged velocity would have been computed independently on each rank, leading to incorrect turbine forcing.

---

## Fix Implemented

The following corrections were made:

1. `this%color` is now explicitly set based on whether the turbine is active on a rank.
2. `MPI_COMM_SPLIT` is performed consistently across all ranks.
3. Reductions (`p_sum`, `p_maxval`) are performed on the correct communicator (`this%mycomm`).
4. The world ranks for which a turbine is active are written to the log for debugging and verification.

This ensures:

- Proper communicator construction.
- Communication limited to the subset of active ranks.
- Elimination of undefined behaviour due to uninitialised memory.
- Removal of redundant memory allocation.

---

## Verification

Since this modification does not alter the physical model but only corrects communicator usage, I verified that the solution remains unchanged.

A streamwise transect of velocity along the wakes of four aligned turbines was compared before and after the fix. The results are identical, confirming that the change affects only communication logic and not the physical solution.

<img width="600" height="400" alt="Fixed_turbine_module_no_effect" src="https://github.com/user-attachments/assets/8c6a9df6-3918-48f7-979b-585d4ed2ea0f" />
